### PR TITLE
fix #12: Make web context root configurable.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>nl.goodbytes.xmpp.xep</groupId>
             <artifactId>httpfileuploadcomponent</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/java/org/igniterealtime/openfire/plugins/httpfileupload/HttpFileUploadPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugins/httpfileupload/HttpFileUploadPlugin.java
@@ -53,10 +53,10 @@ public class HttpFileUploadPlugin implements Plugin, PropertyEventListener
     {
         try
         {
-//            SlotManager.getInstance().setWebPath( "httpfileupload" );
             SlotManager.getInstance().setWebProtocol( JiveGlobals.getProperty( "plugin.httpfileupload.announcedWebProtocol", "https" ) );
             SlotManager.getInstance().setWebHost( JiveGlobals.getProperty( "plugin.httpfileupload.announcedWebHost", XMPPServer.getInstance().getServerInfo().getHostname() ) );
             SlotManager.getInstance().setWebPort( JiveGlobals.getIntProperty( "plugin.httpfileupload.announcedWebPort", HttpBindManager.getInstance().getHttpBindSecurePort() ) );
+            SlotManager.getInstance().setWebContextRoot( JiveGlobals.getProperty( "plugin.httpfileupload.announcedWebContextRoot", "/httpfileupload" ) );
             SlotManager.getInstance().setMaxFileSize( JiveGlobals.getLongProperty( "plugin.httpfileupload.maxFileSize", SlotManager.DEFAULT_MAX_FILE_SIZE ) );
 
             Repository repository;


### PR DESCRIPTION
The URL on which the service is exposed should, by default, match the one that's used by Openfire.