### PR TITLE
DRAFT: Improvements for using in a cluster

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,7 @@
 <p><b>1.2.0</b> -- (tbd)</p>
 <ul>
     <li>Now requires Openfire 4.7.0 or later</li>
+    <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/38">Issue #38:</a> Use SystemProperty to replace old style properties.</li>
     <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/37">Issue #37:</a> When using non-encrypted scheme, default to non-encrypted port.</li>
     <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/33">Issue #33:</a> Fix API incompatiblities with upcoming Openfire 4.8.</li>
 </ul>

--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,14 @@
 <p><b>1.2.0</b> -- (tbd)</p>
 <ul>
     <li>Now requires Openfire 4.7.0 or later</li>
+    <li>Updated to HttpFileUploadComponent v1.5.0, which resolves:</li>
+    <ul>
+        <li><a href="https://github.com/guusdk/httpfileuploadcomponent/issues/38">Issue #38:</a> Update dependencies to latest version</li>
+        <li><a href="https://github.com/guusdk/httpfileuploadcomponent/issues/37">Issue #37:</a> fixes #38: Update dependencies to latest version</li>
+        <li><a href="https://github.com/guusdk/httpfileuploadcomponent/issues/36">Issue #36:</a> Slot and SecureUniqueId should be Serializable</li>
+        <li><a href="https://github.com/guusdk/httpfileuploadcomponent/issues/35">Issue #35:</a> Make slot manager configurable</li>
+    </ul>
+    <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/39">Issue #39:</a> Slot manager should be cluster-aware.</li>
     <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/38">Issue #38:</a> Use SystemProperty to replace old style properties.</li>
     <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/37">Issue #37:</a> When using non-encrypted scheme, default to non-encrypted port.</li>
     <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/33">Issue #33:</a> Fix API incompatiblities with upcoming Openfire 4.8.</li>

--- a/changelog.html
+++ b/changelog.html
@@ -54,6 +54,7 @@
     <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/39">Issue #39:</a> Slot manager should be cluster-aware.</li>
     <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/38">Issue #38:</a> Use SystemProperty to replace old style properties.</li>
     <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/37">Issue #37:</a> When using non-encrypted scheme, default to non-encrypted port.</li>
+    <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/36">Issue #36:</a> Add documentation for configuration in a clustered environment.</li>
     <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/33">Issue #33:</a> Fix API incompatiblities with upcoming Openfire 4.8.</li>
 </ul>
 

--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,7 @@
 <p><b>1.2.0</b> -- (tbd)</p>
 <ul>
     <li>Now requires Openfire 4.7.0 or later</li>
+    <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/37">Issue #37:</a> When using non-encrypted scheme, default to non-encrypted port.</li>
     <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/33">Issue #33:</a> Fix API incompatiblities with upcoming Openfire 4.8.</li>
 </ul>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>nl.goodbytes.xmpp.xep</groupId>
             <artifactId>httpfileuploadcomponent</artifactId>
-            <version>1.4.0</version>
+            <version>1.5.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/readme.html
+++ b/readme.html
@@ -58,8 +58,11 @@
 <h2>Overview</h2>
 
 <p>
-    The HTTP File Upload plugin adds functionality to Openfire that allows compliant clients to exchange files.
+    The HTTP File Upload plugin adds functionality to Openfire that allows compliant clients to exchange files. The
+    protocol implemented by this plugin is defined in <a href="https://xmpp.org/extensions/xep-0363.html">XEP-0363:
+    HTTP File Upload</a>.
 </p>
+
 <p>
     <strong>Note: </strong> This plugin requires the HTTP bind option in Openfire to be enabled:
     <br>Server -> Server Settings -> HTTP Binding
@@ -72,7 +75,7 @@
     automatically deployed. To upgrade to a new version, copy the new httpfileupload.jar file over the existing file.
 </p>
 
-<h2>Configuration</h2>
+<h2 id="configuration">Configuration</h2>
 
 <p>
     By default, the plugin will store all uploaded files in a temporary directory that is provided by the Operating System.
@@ -112,6 +115,117 @@
     files, the plugin by default stores the files that are being transferred in a temporary directory that is removed
     when Openfire is shut down. The content of this directory is purged when its total size is larger than the remaining
     disc space.
+</p>
+
+<h2>When using in an Openfire cluster</h2>
+
+<p>
+    Special consideration needs to be given to the deployment of this plugin in a cluster of Openfire instances. This
+    section outlines the main concerns.
+</p>
+
+<h3>Background: how clients interact with the servers</h3>
+
+<p>
+    Unlike most other XMPP-related functionality, this 'HTTP File Upload' functionality uses an additional data path:
+    not only is the XMPP connection itself used; HTTP requests are also made. The HTTP protocol is used to upload and
+    download data. The URLs for these interactions are sent over the XMPP data channel.
+</p>
+<p>
+    In a typical scenario, a client that wants to send a file requests an 'upload slot' through XMPP. When assigned a
+    slot, its URL (as well as other metadata) is returned to the client by the server. Using this information, the client
+    will then upload the data using a HTTP PUT request. After the upload has succeeded, the client will send, over XMPP,
+    send the URL to the intended recipients of the data. Their clients will receive that URL (over XMPP) and subsequently
+    perform a HTTP GET request to download the data from the web server.
+</p>
+
+<h3>Configuration A: Using multiple service endpoint addresses</h3>
+
+<p>
+    When each of the Openfire cluster node servers is connected directly to the internet, accessible to clients through
+    their fully qualified domain name, then no configuration might be needed to make HTTP File Upload functionality
+    available on all cluster nodes, for all clients.
+</p>
+
+<h4>Option 1: Each Openfire manages a unique set of data</h4>
+
+<p>
+    <em>pro's & cons:</em> This solution requires no configuration, provides adequate scalability, but does not offer
+    much data redundancy or flexibility in network architecture.
+</p>
+
+<p>
+    Since version 1.2.0 of this plugin, the definition of a Slot is shared across all XMPP cluster nodes. This slot
+    defines the endpoint addresses to be used by the uploader, as well as the recipients of the data.
+</p>
+
+<p>
+    In the scenario described by this configuration option, each Openfire cluster node will issue slots that contain
+    endpoint URLs that are specific to the server that issued the slot. This means that the upload, as well as all
+    downloads, will be directed to URL on that same server.
+</p>
+
+<h3>Configuration B: Using one service endpoint address</h3>
+
+<p>
+    In certain environments it is undesirable or unpractical to expose more than one endpoint URL to chat clients. This
+    is frequently the case when the network architecture includes a load balancer. For this or other reasons, it might
+    have been necessary to reconfigure the 'announced' endpoints (using the configuration options defined in the
+    <a href="#configuration">Configuration paragraph</a> of this document) to use the same endpoint address for all
+    requests.
+</p>
+
+<h4>Option 2: Use only one server for file upload/download</h4>
+
+<p>
+    <em>pro's & cons:</em> This solution is typically easy to configure, but provides poor redundancy and
+    scalability.
+</p>
+
+<p>
+    In this scenario, the singular endpoint address could be mapped to exactly one Openfire cluster node. This can be
+    achieved by directly mapping the 'announced' endpoint details to the address of one of the Openfire nodes,
+    (as described in the <a href="#configuration">Configuration paragraph</a> of this document) or by configuring the
+    load balancer to 'balance' the traffic to just one of the nodes.
+</p>
+
+<h4>Option 3: Use every cluster node for file upload/download</h4>
+
+<p>
+    <em>pro's & cons:</em> More complex to configure, but provides better redundancy and scalability.
+</p>
+
+<p>
+    When a singular endpoint address is used, then this option typically involves a load balancer that distributes the
+    HTTP requests over all cluster nodes. This comes with some complexities:
+</p>
+
+<ul>
+    <li>
+        It is hard to ensure that the cluster node used by the XMPP connection of the client sharing/uploading the data
+        is the same cluster node used when performing the HTTP upload.
+    </li>
+    <li>
+        It often impossible to guaranteed that HTTP requests made by intended recipients of the uploaded data end up at
+        the same cluster node as the one that was used to upload the data to.
+    </li>
+</ul>
+
+<p>
+    When using this configuration option, it should be assured that every XMPP cluster node can fulfill HTTP upload and
+    download requests for all slots.
+</p>
+
+<p>
+    Since version 1.2.0 of this plugin, the definition of a Slot is shared across all XMPP cluster nodes. To ensure that
+    all data is accessible, all cluster nodes should use the same shared network folder for file storage. This network
+    folder should be available on the filesystem of each of your Openfire servers, using the same path name. This plugin
+    should be configured to use this directory for data storage, by using the <samp>plugin.httpfileupload.fileRepo</samp>
+    property, as described in the <a href="#configuration">Configuration paragraph</a> of this document.
+</p>
+<p>
+    Realisation of a shared network folder is likely highly specific to the operating system used for your Openfire
+    servers, and is out of scope for this document.
 </p>
 
 <h2>Attribution</h2>

--- a/src/i18n/httpfileupload_i18n.properties
+++ b/src/i18n/httpfileupload_i18n.properties
@@ -1,0 +1,6 @@
+system_property.plugin.httpfileupload.announcedWebContextRoot=Controls the context root that is used in URLs advertised for file uploads/downloads.
+system_property.plugin.httpfileupload.announcedWebHost=Controls the server address that is used in URLs advertised for file uploads/downloads.
+system_property.plugin.httpfileupload.announcedWebPort=Controls the TCP port that is used in URLs advertised for file uploads/downloads.
+system_property.plugin.httpfileupload.announcedWebProtocol=Controls the scheme that is used in URLs advertised for file uploads/downloads.
+system_property.plugin.httpfileupload.fileRepo=Defines the file system path (directory) in which data is stored on the server. If the path is absent, or invalid, a temporary directory will be used.
+system_property.plugin.httpfileupload.maxFileSize=Defines the maximum size (in bytes) of files that can be uploaded.

--- a/src/java/org/igniterealtime/openfire/plugins/httpfileupload/CORSServlet.java
+++ b/src/java/org/igniterealtime/openfire/plugins/httpfileupload/CORSServlet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.igniterealtime.openfire.plugins.httpfileupload;
 
 import nl.goodbytes.xmpp.xep0363.Servlet;

--- a/src/java/org/igniterealtime/openfire/plugins/httpfileupload/HttpFileUploadPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugins/httpfileupload/HttpFileUploadPlugin.java
@@ -166,6 +166,7 @@ public class HttpFileUploadPlugin implements Plugin, PropertyEventListener
         if ( "plugin.httpfileupload.announcedWebProtocol".equals( property ) )
         {
             SlotManager.getInstance().setWebProtocol( JiveGlobals.getProperty( "plugin.httpfileupload.announcedWebProtocol", "https" ) );
+            SlotManager.getInstance().setWebPort( JiveGlobals.getIntProperty( "plugin.httpfileupload.announcedWebPort", "http".equalsIgnoreCase(SlotManager.getInstance().getWebProtocol()) ? HttpBindManager.HTTP_BIND_PORT.getValue() : HttpBindManager.HTTP_BIND_SECURE_PORT.getValue() ) );
         }
         else
 
@@ -177,7 +178,7 @@ public class HttpFileUploadPlugin implements Plugin, PropertyEventListener
 
         if ( "plugin.httpfileupload.announcedWebPort".equals( property ) )
         {
-            SlotManager.getInstance().setWebPort( JiveGlobals.getIntProperty( "plugin.httpfileupload.announcedWebPort", HttpBindManager.HTTP_BIND_SECURE_PORT.getValue() ) );
+            SlotManager.getInstance().setWebPort( JiveGlobals.getIntProperty( "plugin.httpfileupload.announcedWebPort", "http".equalsIgnoreCase(SlotManager.getInstance().getWebProtocol()) ? HttpBindManager.HTTP_BIND_PORT.getValue() : HttpBindManager.HTTP_BIND_SECURE_PORT.getValue() ) );
         }
     }
 
@@ -192,6 +193,7 @@ public class HttpFileUploadPlugin implements Plugin, PropertyEventListener
         if ( "plugin.httpfileupload.announcedWebProtocol".equals( property ) )
         {
             SlotManager.getInstance().setWebProtocol( "https" );
+            SlotManager.getInstance().setWebPort( JiveGlobals.getIntProperty( "plugin.httpfileupload.announcedWebPort", HttpBindManager.HTTP_BIND_SECURE_PORT.getValue() ) );
         }
         else
 
@@ -203,7 +205,7 @@ public class HttpFileUploadPlugin implements Plugin, PropertyEventListener
 
         if ( "plugin.httpfileupload.announcedWebPort".equals( property ) )
         {
-            SlotManager.getInstance().setWebPort( HttpBindManager.HTTP_BIND_SECURE_PORT.getValue() );
+            SlotManager.getInstance().setWebPort( JiveGlobals.getIntProperty( "plugin.httpfileupload.announcedWebPort", "http".equalsIgnoreCase(SlotManager.getInstance().getWebProtocol()) ? HttpBindManager.HTTP_BIND_PORT.getValue() : HttpBindManager.HTTP_BIND_SECURE_PORT.getValue() ) );
         }
     }
 }

--- a/src/java/org/igniterealtime/openfire/plugins/httpfileupload/HttpFileUploadPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugins/httpfileupload/HttpFileUploadPlugin.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.igniterealtime.openfire.plugins.httpfileupload;
 
 import nl.goodbytes.xmpp.xep0363.Component;

--- a/src/java/org/igniterealtime/openfire/plugins/httpfileupload/HttpFileUploadPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugins/httpfileupload/HttpFileUploadPlugin.java
@@ -1,13 +1,11 @@
 package org.igniterealtime.openfire.plugins.httpfileupload;
 
-import java.io.File;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import nl.goodbytes.xmpp.xep0363.Component;
+import nl.goodbytes.xmpp.xep0363.Repository;
+import nl.goodbytes.xmpp.xep0363.RepositoryManager;
+import nl.goodbytes.xmpp.xep0363.SlotManager;
+import nl.goodbytes.xmpp.xep0363.repository.DirectoryRepository;
+import nl.goodbytes.xmpp.xep0363.repository.TempDirectoryRepository;
 import org.apache.tomcat.InstanceManager;
 import org.apache.tomcat.SimpleInstanceManager;
 import org.eclipse.jetty.apache.jsp.JettyJasperInitializer;

--- a/src/java/org/igniterealtime/openfire/plugins/httpfileupload/OpenfireSlotProvider.java
+++ b/src/java/org/igniterealtime/openfire/plugins/httpfileupload/OpenfireSlotProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.igniterealtime.openfire.plugins.httpfileupload;
 
 import nl.goodbytes.xmpp.xep0363.SecureUniqueId;

--- a/src/java/org/igniterealtime/openfire/plugins/httpfileupload/OpenfireSlotProvider.java
+++ b/src/java/org/igniterealtime/openfire/plugins/httpfileupload/OpenfireSlotProvider.java
@@ -1,0 +1,52 @@
+package org.igniterealtime.openfire.plugins.httpfileupload;
+
+import nl.goodbytes.xmpp.xep0363.SecureUniqueId;
+import nl.goodbytes.xmpp.xep0363.Slot;
+import nl.goodbytes.xmpp.xep0363.SlotProvider;
+import org.jivesoftware.util.JiveGlobals;
+import org.jivesoftware.util.cache.Cache;
+import org.jivesoftware.util.cache.CacheFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.Duration;
+import java.util.concurrent.locks.Lock;
+
+public class OpenfireSlotProvider implements SlotProvider
+{
+    private final Cache<SecureUniqueId, Slot> slotsCache;
+
+    public OpenfireSlotProvider() {
+        slotsCache = CacheFactory.createCache("HTTP File Upload Slots");
+
+        // Unless there is specific configuration for this cache, default the max lifetime of entries in this cache to something that's fairly short.
+        if (null == JiveGlobals.getProperty("cache." + slotsCache.getName().replaceAll(" ", "") + ".maxLifetime")) {
+            slotsCache.setMaxCacheSize(Duration.ofMinutes(5).toMillis());
+        }
+    }
+
+    @Override
+    public void create(@Nonnull final Slot slot)
+    {
+        final Lock lock = slotsCache.getLock(slot.getUuid());
+        lock.lock();
+        try {
+            slotsCache.put( slot.getUuid(), slot );
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Nullable
+    @Override
+    public Slot consume(@Nonnull final SecureUniqueId slotId)
+    {
+        final Lock lock = slotsCache.getLock(slotId);
+        lock.lock();
+        try {
+            return slotsCache.remove(slotId);
+        } finally {
+            lock.unlock();
+        }
+    }
+}


### PR DESCRIPTION
This PR includes fixes for the following issues:

- #36
- #37 
- #38 
- #39 

Please refer to the commit messages of each individual commit for specific details on each fix.

These aim to document and improve the application of the HTTP File Upload plugin in a _cluster_ of Openfire servers.

This PR is created as a draft, to gather feedback on:
- generically: implementation details
- the wording of the documentation provided to address issue #36
- the correctness of the documentation (we need to test each configuration/option to make sure that what is documented is correct).

Before this PR can be merged, the fix for issue #39 should modified to no longer use a SNAPSHOT version of the httpfileuploadcomponent dependency. Instead, a proper release should be used. I have not yet created that release, as the changes in the SNAPSHOT themselves might be changed as a result of reviewing this PR.