### PR TITLE
fix #43: Prevent ClassCastExceptions after plugin gets reloaded in a cluster

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -41,6 +41,12 @@
 
 <h1>HTTP File Upload Plugin Changelog</h1>
 
+<p><b>1.5.0</b> -- (tbd)</p>
+<ul>
+    <li>Now requires Openfire 4.8.1 or later</li>
+    <li><a href="https://github.com/igniterealtime/openfire-httpFileUpload-plugin/issues/43">Issue #43:</a> ClassCastExceptions after reloading plugin in a cluster.</li>
+</ul>
+
 <p><b>1.4.2</b> -- (November 19, 2024)</p>
 <ul>
     <li>Updated Chinese (zh_CN) translation</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <author>Guus der Kinderen</author>
     <version>${project.version}</version>
     <date>2024-11-19</date>
-    <minServerVersion>4.7.0</minServerVersion>
+    <minServerVersion>4.8.1</minServerVersion>
     <priorToServerVersion>5.0.0</priorToServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
     <csrfProtectionEnabled>true</csrfProtectionEnabled>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.0</version>
+        <version>4.8.1</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>httpfileupload</artifactId>
     <name>HTTP File Upload Plugin</name>
     <description>Allows clients to share files, as described in the XEP-0363 'HTTP File Upload' specification.</description>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.5.0-SNAPSHOT</version>
 
     <distributionManagement>
         <!-- Repository in which we deploy this project, when desired. -->

--- a/src/java/org/igniterealtime/openfire/plugins/httpfileupload/OpenfireSlotProvider.java
+++ b/src/java/org/igniterealtime/openfire/plugins/httpfileupload/OpenfireSlotProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2022 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (c) 2017-2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,11 @@ import java.util.concurrent.locks.Lock;
 
 public class OpenfireSlotProvider implements SlotProvider
 {
-    private final Cache<SecureUniqueId, Slot> slotsCache;
+    // Use string-representation of SecureUniqueId as cache key, as the interface cannot be processed by JAXB.
+    private final Cache<String, Slot> slotsCache;
 
     public OpenfireSlotProvider() {
-        slotsCache = CacheFactory.createCache("HTTP File Upload Slots");
+        slotsCache = CacheFactory.createSerializingCache("HTTP File Upload Slots", String.class, Slot.class);
 
         // Unless there is specific configuration for this cache, default the max lifetime of entries in this cache to something that's fairly short.
         if (null == JiveGlobals.getProperty("cache." + slotsCache.getName().replaceAll(" ", "") + ".maxLifetime")) {
@@ -43,10 +44,10 @@ public class OpenfireSlotProvider implements SlotProvider
     @Override
     public void create(@Nonnull final Slot slot)
     {
-        final Lock lock = slotsCache.getLock(slot.getUuid());
+        final Lock lock = slotsCache.getLock(slot.getUuid().toString());
         lock.lock();
         try {
-            slotsCache.put( slot.getUuid(), slot );
+            slotsCache.put( slot.getUuid().toString(), slot );
         } finally {
             lock.unlock();
         }
@@ -56,10 +57,10 @@ public class OpenfireSlotProvider implements SlotProvider
     @Override
     public Slot consume(@Nonnull final SecureUniqueId slotId)
     {
-        final Lock lock = slotsCache.getLock(slotId);
+        final Lock lock = slotsCache.getLock(slotId.toString());
         lock.lock();
         try {
-            return slotsCache.remove(slotId);
+            return slotsCache.remove(slotId.toString());
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
This plugin caches instances of classes that are defined in the code of the plugin. This causes ClassCastExceptions, when the plugin gets unloaded (removing the class definitions) and updated/reloaded (replacing the class definitions). The cached values at that time will refer to classes that no longer exist, causing the exceptions.

https://igniterealtime.atlassian.net/browse/OF-2239 introduces a new type of Cache to work around this problem, the org.jivesoftware.util.cache.SerializingCache which is available since Openfire 4.7.0. This implementation does not cache the instance directly, but caches a serialized version instead. This way, there no longer is a reference to the class, which means that any (compatible) future class definition can be used to instantiate the cache entry again.