### PR TITLE
CI: Switch to build as defined in centralized GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,72 +3,8 @@ name: Java CI
 on: [push, pull_request]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ "8", "11" ]
-
-    steps:
-      # Checkout Repo
-      - uses: actions/checkout@v3
-
-      # Create a variable with this plugin's name
-      - id: get-id
-        name: Compute needed variables
-        run: |
-          set -x
-          id=$(mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout)
-          echo "id=$id" >> $GITHUB_OUTPUT
-          echo "id is '$id'"
-          tag=$(echo ${{ github.ref }} | cut -d '/' -f3)
-          echo "tag=$tag" >> $GITHUB_OUTPUT
-          echo "tag is '$tag'"
-          version=$(echo ${{ github.ref }} | cut -d '/' -f3 | cut -c 2-)
-          echo "version=$version" >> $GITHUB_OUTPUT
-          echo "version is '$version'"
-          rel_id=$(curl -sL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/${{github.repository}}/releases | jq -r --arg TAG "$tag" '.[] | select(.tag_name==$TAG) | .id')
-          echo "rel_id=$rel_id" >> $GITHUB_OUTPUT
-          echo "rel_id is '$rel_id'"
-
-      - name: Setup JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: temurin
-
-      - name: Cache Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-java${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-java${{ matrix.java }}-maven-
-            ${{ runner.os }}-
-
-      - name: Igniterealtime CI Tooling
-        run: |
-          git clone --depth 1 https://github.com/igniterealtime/ci-tooling.git target/ci-tooling
-          cp target/ci-tooling/maven-settings-for-openfire-plugins.xml $HOME/.m2/settings.xml
-
-      - name: Build with Maven
-        run:  mvn -B package
-
-      - name: Conditionally Deploy to Igniterealtime Archiva
-        id: deploy
-        if: ${{ contains(github.repository, 'igniterealtime/') && ( ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) || contains(github.ref, 'refs/tags/') ) && matrix.java == '8' }}
-        run: mvn -B deploy -Dmaven.resolver.transport=wagon --settings target/ci-tooling/maven-settings-for-openfire-plugins.xml
-        env:
-          CI_DEPLOY_USERNAME: ${{ secrets.IGNITE_REALTIME_MAVEN_USERNAME }}
-          CI_DEPLOY_PASSWORD: ${{ secrets.IGNITE_REALTIME_MAVEN_PASSWORD }}
-
-      - name: Conditionally Push Artifact to Github Release
-        uses: actions/upload-release-asset@v1
-        if: ${{ contains(github.repository, 'igniterealtime/') && github.event_name == 'push' && contains(github.ref, 'refs/tags/') && matrix.java == '8' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.get-id.outputs.rel_id }}/assets?name=${{ steps.get-id.outputs.id }}.jar
-          asset_path: target/${{ steps.get-id.outputs.id }}-openfire-plugin-assembly.jar
-          asset_name: ${{ steps.get-id.outputs.id }}.jar
-          asset_content_type: application/java-archive
+    build:
+        uses: igniterealtime/openfire-plugin-builder-action/.github/workflows/openfire-plugin-build.yml@main
+        secrets:
+            IGNITE_REALTIME_MAVEN_USERNAME: ${{ secrets.IGNITE_REALTIME_MAVEN_USERNAME }}
+            IGNITE_REALTIME_MAVEN_PASSWORD: ${{ secrets.IGNITE_REALTIME_MAVEN_PASSWORD }}


### PR DESCRIPTION
Use `igniterealtime/openfire-plugin-builder-action` for easier maintenance.

From a cursory look, this GitHub Action has been modified to account for the change needed to fix #31